### PR TITLE
For convenience, map http/https to ws/wss

### DIFF
--- a/main.go
+++ b/main.go
@@ -67,6 +67,12 @@ func MustParseURL(u string) *url.URL {
 	if err != nil {
 		log.Fatalf("Unable to parse URL: %v: %v", u, err)
 	}
+	switch tgt.Scheme {
+	case "http":
+		tgt.Scheme = "ws"
+	case "https":
+		tgt.Scheme = "wss"
+	}
 	return tgt
 }
 


### PR DESCRIPTION
As a convenience, this makes it possible to use URLs which have the HTTP scheme.
